### PR TITLE
Fix inconsistent spacing around RSVP focal letter

### DIFF
--- a/apps/web/components/reader.tsx
+++ b/apps/web/components/reader.tsx
@@ -515,6 +515,9 @@ export function Reader(props: ReaderProps): React.ReactElement | null {
     () => getWordParts(activeWord),
     [activeWord],
   );
+  const wordFocalContainerRef = useRef<HTMLDivElement>(null);
+  const wordLineRef = useRef<HTMLDivElement>(null);
+  const [focalTranslateX, setFocalTranslateX] = useState(0);
   const mountedRef = useRef(false);
 
   const setEffectiveWordIndex = useCallback(
@@ -752,8 +755,6 @@ export function Reader(props: ReaderProps): React.ReactElement | null {
     setIsPlaying(false);
   }
 
-  if (!isFull && words.length === 0) return null;
-
   const isPanelFillHeight =
     props.variant === "panel" && (props as ReaderPanelProps).fillHeight;
 
@@ -772,6 +773,64 @@ export function Reader(props: ReaderProps): React.ReactElement | null {
     FONT_FAMILIES[effectiveFontFamily].className,
   );
   const focalColorClassName = FOCAL_COLORS[effectiveFocalColor].className;
+
+  // Keep the focal grapheme centered on the guide; one inline line preserves kerning (split grid cells do not).
+  useLayoutEffect(() => {
+    let cancelled = false;
+    let raf = 0;
+
+    function measure() {
+      const container = wordFocalContainerRef.current;
+      const line = wordLineRef.current;
+      if (!container || !line || words.length === 0) {
+        setFocalTranslateX(0);
+        return;
+      }
+      const focalEl = line.querySelector<HTMLElement>("[data-focal-letter]");
+      if (!focalEl) {
+        setFocalTranslateX(0);
+        return;
+      }
+      const cr = container.getBoundingClientRect();
+      const guideX = cr.left + cr.width / 2;
+      const fr = focalEl.getBoundingClientRect();
+      const focalCenterX = fr.left + fr.width / 2;
+      setFocalTranslateX(guideX - focalCenterX);
+    }
+
+    function scheduleMeasure() {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        if (cancelled) return;
+        measure();
+      });
+    }
+
+    if (typeof document !== "undefined" && document.fonts?.ready) {
+      void document.fonts.ready.then(scheduleMeasure);
+    } else {
+      scheduleMeasure();
+    }
+
+    const container = wordFocalContainerRef.current;
+    const ro = new ResizeObserver(scheduleMeasure);
+    if (container) ro.observe(container);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [
+    activeWord,
+    activeWordIndex,
+    focalCharacter,
+    left,
+    right,
+    words.length,
+    wordDisplayClassName,
+  ]);
+
+  if (!isFull && words.length === 0) return null;
 
   const content = (
     <>
@@ -805,18 +864,27 @@ export function Reader(props: ReaderProps): React.ReactElement | null {
           />
 
           <div
-            className={cn(
-              "grid w-full max-w-2xl grid-cols-[1fr_auto_1fr] items-baseline px-3 leading-none sm:px-6",
-              wordDisplayClassName,
-            )}
+            ref={wordFocalContainerRef}
+            className="flex w-full max-w-2xl justify-center overflow-hidden px-3 sm:px-6"
           >
-            <span className="justify-self-end pr-1 text-zinc-700 dark:text-zinc-100">
-              {left}
-            </span>
-            <span className={focalColorClassName}>{focalCharacter || "•"}</span>
-            <span className="justify-self-start pl-1 text-zinc-700 dark:text-zinc-100">
-              {right}
-            </span>
+            <div
+              ref={wordLineRef}
+              className={cn(
+                "inline-flex max-w-full whitespace-nowrap leading-none",
+                wordDisplayClassName,
+              )}
+              style={{ transform: `translateX(${focalTranslateX}px)` }}
+            >
+              {left ? (
+                <span className="text-zinc-700 dark:text-zinc-100">{left}</span>
+              ) : null}
+              <span className={focalColorClassName} data-focal-letter>
+                {focalCharacter || "•"}
+              </span>
+              {right ? (
+                <span className="text-zinc-700 dark:text-zinc-100">{right}</span>
+              ) : null}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was wrong

Git history shows the last commit only changed copy (About + sample text); it did not touch the word display.

The uneven gaps came from the RSVP layout: the word was split into **three CSS grid columns** (`grid-cols-[1fr_auto_1fr]`) with `pr-1` / `pl-1`. Putting substrings in **separate grid cells** breaks **font kerning** (pair adjustments only apply within a single shaping run), so spacing between the focal letter and neighbors could look too tight, too loose, or fine depending on the font and letter pairs.

Earlier related changes (for context): `7db3149` switched focal splitting to grapheme clusters; `ddfcb1f` introduced the three-column grid.

## Fix

- Render `left | focal | right` as **one inline line** (`inline-flex` + `whitespace-nowrap`) so kerning applies across the whole word.
- Use `translateX` from a `ResizeObserver` + `requestAnimationFrame` (and `document.fonts.ready`) so the **focal glyph stays centered** on the vertical guide.

## Testing

- `bun test`, `bun run --filter wordflash lint`, `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccb9ea9d-381b-4be1-bdc7-3d147deea26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccb9ea9d-381b-4be1-bdc7-3d147deea26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

